### PR TITLE
Add quotes around connect_to docs to match usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Typing `jobs_help`, you'll get clear instructions about how to switch between ap
 ```
 >> jobs_help
 You can connect to a job server with
-  connect_to <app_id>:<server_id>
+  connect_to "<app_id>:<server_id>"
 
 Available job servers:
   * bc4:resque_ashburn

--- a/lib/mission_control/jobs/console/helpers.rb
+++ b/lib/mission_control/jobs/console/helpers.rb
@@ -11,7 +11,7 @@ module MissionControl::Jobs::Console::Helpers
     puts "You are currently connected to #{MissionControl::Jobs::Current.server}" if MissionControl::Jobs::Current.server
 
     puts "You can connect to a job server with"
-    puts "  connect_to <app_id>:<server_id>\n\n"
+    puts '  connect_to "<app_id>:<server_id>"\n\n'
 
     puts "Available job servers:\n"
 

--- a/lib/mission_control/jobs/console/helpers.rb
+++ b/lib/mission_control/jobs/console/helpers.rb
@@ -11,7 +11,7 @@ module MissionControl::Jobs::Console::Helpers
     puts "You are currently connected to #{MissionControl::Jobs::Current.server}" if MissionControl::Jobs::Current.server
 
     puts "You can connect to a job server with"
-    puts '  connect_to "<app_id>:<server_id>"\n\n'
+    puts %(  connect_to "<app_id>:<server_id>"\n\n)
 
     puts "Available job servers:\n"
 


### PR DESCRIPTION
I noticed in the current instructions the quotes were missing for the `connect_to` argument so I was a bit confused on what to pass in:
<img width="586" alt="Screenshot 2024-01-31 at 8 17 29 AM" src="https://github.com/basecamp/mission_control-jobs/assets/67093/ad9df748-cd1f-4805-82d6-9da642058941">

This updates the docs to use `connect_to "app_id:server_id"` to match the actual usage.