### PR TITLE
Don't reference any actions in JobScoped concern, as it might not exist

### DIFF
--- a/app/controllers/concerns/mission_control/jobs/job_scoped.rb
+++ b/app/controllers/concerns/mission_control/jobs/job_scoped.rb
@@ -2,7 +2,7 @@ module MissionControl::Jobs::JobScoped
   extend ActiveSupport::Concern
 
   included do
-    before_action :set_job, except: :index
+    before_action :set_job
   end
 
   private

--- a/app/controllers/mission_control/jobs/jobs_controller.rb
+++ b/app/controllers/mission_control/jobs/jobs_controller.rb
@@ -1,6 +1,8 @@
 class MissionControl::Jobs::JobsController < MissionControl::Jobs::ApplicationController
   include MissionControl::Jobs::JobScoped, MissionControl::Jobs::JobFilters
 
+  skip_before_action :set_job, only: :index
+
   def index
     @job_class_names = jobs_with_status.job_class_names
     @queue_names = ApplicationJob.queues.map(&:name)


### PR DESCRIPTION
Thanks to @excid3 for spotting this in #46! 

In Rails 7.1, because of the new default for `config.action_controller.raise_on_missing_callback_actions`, the except option used in `before_action` for `index` raises an error for those controllers that don't have an index action. Let's just remove that and let the only controller with an index action using this concern opt-out of it explicitly.