### PR TITLE
Connect to default app:server if only one is defined

### DIFF
--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -71,6 +71,11 @@ module MissionControl
         MissionControl::Jobs.delay_between_bulk_operation_batches = 2
         MissionControl::Jobs.logger = ActiveSupport::Logger.new(STDOUT)
 
+        if MissionControl::Jobs.applications.one? && (application = MissionControl::Jobs.applications.first) && application.servers.one?
+          MissionControl::Jobs::Current.application = application
+          MissionControl::Jobs::Current.server = application.servers.first
+        end
+
         puts "\n\nType 'jobs_help' to see how to connect to the available job servers to manage jobs\n\n"
       end
 


### PR DESCRIPTION
This automatically sets the current app & server in the Rails console if only one app & server exist.

Closes #41