### PR TITLE
add pagination to workers page

### DIFF
--- a/app/controllers/mission_control/jobs/workers_controller.rb
+++ b/app/controllers/mission_control/jobs/workers_controller.rb
@@ -3,6 +3,8 @@ class MissionControl::Jobs::WorkersController < MissionControl::Jobs::Applicatio
 
   def index
     @workers = MissionControl::Jobs::Current.server.workers.sort_by { |worker| -worker.jobs.count }
+    @workers_page = MissionControl::Jobs::Workers::Page.new(@workers, page: params[:page].to_i)
+    @workers_count = @workers_page.total_count
   end
 
   def show

--- a/app/models/mission_control/jobs/workers/page.rb
+++ b/app/models/mission_control/jobs/workers/page.rb
@@ -1,0 +1,48 @@
+class MissionControl::Jobs::Workers::Page
+  DEFAULT_PAGE_SIZE = 10
+
+  attr_reader :index, :page_size, :workers_relation
+
+  def initialize(workers_relation, page: 1, page_size: DEFAULT_PAGE_SIZE)
+    @workers_relation = workers_relation
+    @page_size = page_size
+    @index = [ page, 1 ].max
+  end
+
+  def workers
+    workers_relation[offset...offset + page_size]
+  end
+
+  def first?
+    index == 1
+  end
+
+  def last?
+    index == pages_count || empty? || workers.empty?
+  end
+
+  def empty?
+    total_count == 0
+  end
+
+  def previous_index
+    [ index - 1, 1 ].max
+  end
+
+  def next_index
+    pages_count ? [ index + 1, pages_count ].min : index + 1
+  end
+
+  def pages_count
+    (total_count.to_f / 10).ceil unless total_count.infinite?
+  end
+
+  def total_count
+    @total_count ||= workers_relation.count
+  end
+
+  private
+    def offset
+      (index - 1) * page_size
+    end
+end

--- a/app/views/mission_control/jobs/jobs/index.html.erb
+++ b/app/views/mission_control/jobs/jobs/index.html.erb
@@ -13,7 +13,7 @@
   <% else %>
     <%= render "mission_control/jobs/jobs/jobs_page", jobs_page: @jobs_page %>
 
-    <%= render "mission_control/jobs/shared/pagination_toolbar", jobs_page: @jobs_page %>
+    <%= render "mission_control/jobs/shared/pagination_toolbar", page: @jobs_page %>
   <% end %>
 <% end %>
 

--- a/app/views/mission_control/jobs/queues/show.html.erb
+++ b/app/views/mission_control/jobs/queues/show.html.erb
@@ -19,7 +19,7 @@
     </tbody>
   </table>
 
-  <%= render "mission_control/jobs/shared/pagination_toolbar", jobs_page: @jobs_page %>
+  <%= render "mission_control/jobs/shared/pagination_toolbar", page: @jobs_page %>
 <% end %>
 
 

--- a/app/views/mission_control/jobs/shared/_pagination_toolbar.html.erb
+++ b/app/views/mission_control/jobs/shared/_pagination_toolbar.html.erb
@@ -1,5 +1,5 @@
 <nav class="buttons is-right" role="navigation" aria-label="pagination">
-  <span class="mr-3"><%= jobs_page.index %> / <%= jobs_page.pages_count || "..." %></span>
-  <%= link_to "Previous page", url_for(page: jobs_page.previous_index, **jobs_filter_param), class: "pagination-previous", disabled: jobs_page.first? %>
-  <%= link_to "Next page", url_for(page: jobs_page.next_index, **jobs_filter_param), class: "pagination-next", disabled: jobs_page.last? %>
+  <span class="mr-3"><%= page.index %> / <%= page.pages_count || "..." %></span>
+  <%= link_to "Previous page", url_for(page: page.previous_index, **jobs_filter_param), class: "pagination-previous", disabled: page.first? %>
+  <%= link_to "Next page", url_for(page: page.next_index, **jobs_filter_param), class: "pagination-next", disabled: page.last? %>
 </nav>

--- a/app/views/mission_control/jobs/workers/_workers_page.html.erb
+++ b/app/views/mission_control/jobs/workers/_workers_page.html.erb
@@ -1,0 +1,15 @@
+<table class="workers table jobs is-hoverable is-fullwidth">
+  <tbody>
+  <thead>
+  <tr>
+    <th>Worker</th>
+    <th>Hostname</th>
+    <th style="width: 35%;">Jobs</th>
+    <th>Last heartbeat</th>
+  </tr>
+  </thead>
+
+    <%= render partial: "mission_control/jobs/workers/worker", collection: @workers_page.workers %>
+
+  </tbody>
+</table>

--- a/app/views/mission_control/jobs/workers/index.html.erb
+++ b/app/views/mission_control/jobs/workers/index.html.erb
@@ -1,17 +1,7 @@
 <% navigation(title: "Workers", section: :workers)  %>
-
-<table class="workers table jobs is-hoverable is-fullwidth">
-  <tbody>
-  <thead>
-  <tr>
-    <th>Worker</th>
-    <th>Hostname</th>
-    <th style="width: 35%;">Jobs</th>
-    <th>Last heartbeat</th>
-  </tr>
-  </thead>
-
-  <%= render partial: "mission_control/jobs/workers/worker", collection: @workers %>
-
-  </tbody>
-</table>
+<% if @workers_page.empty? %>
+  <%= blank_status_notice "No workers found with the given filters" %>
+<% else %>
+  <%= render partial: "mission_control/jobs/workers/workers_page" %>
+  <%= render "mission_control/jobs/shared/pagination_toolbar", page: @workers_page %>
+<% end %>


### PR DESCRIPTION
fix #28

1. Created `MissionControl::Jobs::Workers::Page` similar to `MissionControl::Jobs::Page`
2. Refactored pagination toolbar to be reusable
3. Added `_workers_page` partial similar to `_jobs_page`