### PR TITLE
Add `internal_query_count_limit` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Besides `base_controller_class`, you can also set the following for `MissionCont
 - `logger`:  the logger you want Mission Control Jobs to use. Defaults to `ActiveSupport::Logger.new(nil)` (no logging). Notice that this is different from Active Job's logger or Active Job's backend's configured logger.
 - `delay_between_bulk_operation_batches`: how long to wait between batches when performing bulk operations, such as _discard all_ or _retry all_ jobs—defaults to `0`
 - `adapters`: a list of adapters that you want Mission Control to use and extend. By default this will be the adapter you have set for `active_job.queue_adapter`.
+- `internal_query_count_limit`: the maximum number of jobs that Solid Queue adapters will query when performing a count. True counts above this number will be returned as `INFINITY`. This keeps count queries fast—defaults to `500,000`
 
 This library extends Active Job with a querying interface and the following setting:
 - `config.active_job.default_page_size`: the internal batch size that Active Job will use when sending queries to the underlying adapter and the batch size for the bulk operations defined above—defaults to `1000`.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Besides `base_controller_class`, you can also set the following for `MissionCont
 - `logger`:  the logger you want Mission Control Jobs to use. Defaults to `ActiveSupport::Logger.new(nil)` (no logging). Notice that this is different from Active Job's logger or Active Job's backend's configured logger.
 - `delay_between_bulk_operation_batches`: how long to wait between batches when performing bulk operations, such as _discard all_ or _retry all_ jobs—defaults to `0`
 - `adapters`: a list of adapters that you want Mission Control to use and extend. By default this will be the adapter you have set for `active_job.queue_adapter`.
-- `internal_query_count_limit`: the maximum number of jobs that Solid Queue adapters will query when performing a count. True counts above this number will be returned as `INFINITY`. This keeps count queries fast—defaults to `500,000`
+- `internal_query_count_limit`: in count queries, the maximum number of records that will be counted if the adapter needs to limit these queries. True counts above this number will be returned as `INFINITY`. This keeps count queries fast—defaults to `500,000`
 
 This library extends Active Job with a querying interface and the following setting:
 - `config.active_job.default_page_size`: the internal batch size that Active Job will use when sending queries to the underlying adapter and the batch size for the bulk operations defined above—defaults to `1000`.

--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -224,11 +224,10 @@ module ActiveJob::QueueAdapters::SolidQueueExt
           solid_queue_status.finished? ? finished_jobs.count : executions.count
         end
 
-        INTERNAL_COUNT_LIMIT = 500_000 # Hard limit to keep unlimited count queries fast enough
-
         def internally_limited_count
-          limited_count = solid_queue_status.finished? ? finished_jobs.limit(INTERNAL_COUNT_LIMIT + 1).count : executions.limit(INTERNAL_COUNT_LIMIT + 1).count
-          (limited_count == INTERNAL_COUNT_LIMIT + 1) ? Float::INFINITY : limited_count
+          count_limit = MissionControl::Jobs.internal_query_count_limit + 1
+          limited_count = solid_queue_status.finished? ? finished_jobs.limit(count_limit).count : executions.limit(count_limit).count
+          (limited_count == count_limit) ? Float::INFINITY : limited_count
         end
 
         def execution_class_by_status

--- a/lib/mission_control/jobs.rb
+++ b/lib/mission_control/jobs.rb
@@ -15,5 +15,6 @@ module MissionControl
     mattr_accessor :base_controller_class, default: "::ApplicationController"
     mattr_accessor :delay_between_bulk_operation_batches, default: 0
     mattr_accessor :logger, default: ActiveSupport::Logger.new(nil)
+    mattr_accessor :internal_query_count_limit, default: 500_000 # Hard limit to keep unlimited count queries fast enough
   end
 end


### PR DESCRIPTION
This allows the [internal count limit in Solid Queue to be configured](https://github.com/basecamp/mission_control-jobs/issues/34) using an `internal_query_count_limit` option.

```ruby
MissionControl::Jobs.internal_query_count_limit = 5_000
# or
config.mission_control.jobs.internal_query_count_limit = 5_000
```

The default value is `500,000`.