### PR TITLE
Bump mono_logger for to get a fix for Ruby 3.3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,7 +38,7 @@ jobs:
       BUNDLE_GITHUB__COM: x-access-token:${{ secrets.GH_TOKEN }}
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
     services:
       redis:
         image: redis:4.0-alpine

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.2)
     mocha (1.14.0)
-    mono_logger (1.1.1)
+    mono_logger (1.1.2)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
@@ -233,8 +233,8 @@ GEM
     rdoc (6.6.2)
       psych (>= 4.0.0)
     redis (4.0.3)
-    redis-namespace (1.8.2)
-      redis (>= 3.0.4)
+    redis-namespace (1.11.0)
+      redis (>= 4)
     regexp_parser (2.5.0)
     reline (0.4.2)
       io-console (~> 0.5)
@@ -315,6 +315,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/test/active_job/queue_adapters/solid_queue_test.rb
+++ b/test/active_job/queue_adapters/solid_queue_test.rb
@@ -13,7 +13,7 @@ class ActiveJob::QueueAdapters::SolidQueueTest < ActiveSupport::TestCase
     end
 
     def perform_enqueued_jobs
-      worker = SolidQueue::Worker.new(queues: "*", threads: 1, polling_interval: 0)
+      worker = SolidQueue::Worker.new(queues: "*", threads: 1, polling_interval: 0.01)
       worker.mode = :inline
       worker.start
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,15 +11,15 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2023_09_14_113326) do
-  create_table "posts", force: :cascade do |t|
+  create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "solid_queue_blocked_executions", force: :cascade do |t|
-    t.integer "job_id", null: false
+  create_table "solid_queue_blocked_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.string "concurrency_key", null: false
@@ -30,22 +30,22 @@ ActiveRecord::Schema[7.1].define(version: 2023_09_14_113326) do
     t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
   end
 
-  create_table "solid_queue_claimed_executions", force: :cascade do |t|
-    t.integer "job_id", null: false
+  create_table "solid_queue_claimed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
     t.bigint "process_id"
     t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
     t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
   end
 
-  create_table "solid_queue_failed_executions", force: :cascade do |t|
-    t.integer "job_id", null: false
+  create_table "solid_queue_failed_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
     t.text "error"
     t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
   end
 
-  create_table "solid_queue_jobs", force: :cascade do |t|
+  create_table "solid_queue_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "queue_name", null: false
     t.string "class_name", null: false
     t.text "arguments"
@@ -63,13 +63,13 @@ ActiveRecord::Schema[7.1].define(version: 2023_09_14_113326) do
     t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
   end
 
-  create_table "solid_queue_pauses", force: :cascade do |t|
+  create_table "solid_queue_pauses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "queue_name", null: false
     t.datetime "created_at", null: false
     t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
   end
 
-  create_table "solid_queue_processes", force: :cascade do |t|
+  create_table "solid_queue_processes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "kind", null: false
     t.datetime "last_heartbeat_at", null: false
     t.bigint "supervisor_id"
@@ -81,8 +81,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_09_14_113326) do
     t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
   end
 
-  create_table "solid_queue_ready_executions", force: :cascade do |t|
-    t.integer "job_id", null: false
+  create_table "solid_queue_ready_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.datetime "created_at", null: false
@@ -91,8 +91,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_09_14_113326) do
     t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
   end
 
-  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
-    t.integer "job_id", null: false
+  create_table "solid_queue_scheduled_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.datetime "scheduled_at", null: false
@@ -101,7 +101,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_09_14_113326) do
     t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
   end
 
-  create_table "solid_queue_semaphores", force: :cascade do |t|
+  create_table "solid_queue_semaphores", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "key", null: false
     t.integer "value", default: 1, null: false
     t.datetime "expires_at", null: false

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -40,7 +40,7 @@ class JobsLoader
         worker = Resque::Worker.new("*")
         worker.work(0.0)
       when :solid_queue
-        worker = SolidQueue::Worker.new(queues: "*", threads: 1, polling_interval: 0)
+        worker = SolidQueue::Worker.new(queues: "*", threads: 1, polling_interval: 0.01)
         worker.mode = :inline
         worker.start
       else

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,7 +78,7 @@ class ActionDispatch::IntegrationTest
 
     @application = MissionControl::Jobs.applications["integration-tests"]
     @server = @application.servers[:solid_queue]
-    @worker = SolidQueue::Worker.new(queues: "*", threads: 2, polling_interval: 0)
+    @worker = SolidQueue::Worker.new(queues: "*", threads: 2, polling_interval: 0.01)
   end
 
   teardown do


### PR DESCRIPTION
See https://github.com/resque/resque/issues/1856 and https://github.com/steveklabnik/mono_logger/pull/12. 

Besides, fix an inconsistency I spotted in `db/schema.rb` with the foreign key types and add Ruby 3.3.0 to the matrix of versions to test. 

This fixes https://github.com/basecamp/mission_control-jobs/issues/43. 