### PR TITLE
Set :async adapter if there's no adapter configured

### DIFF
--- a/lib/mission_control/jobs/adapter.rb
+++ b/lib/mission_control/jobs/adapter.rb
@@ -29,7 +29,7 @@ module MissionControl::Jobs::Adapter
   # with these attributes:
   #   {
   #     id: 123,
-  #     name: "adapter-name",
+  #     name: "worker-name",
   #     hostname: "hey-default-101",
   #     last_heartbeat_at: Fri, 26 Jan 2024 20:31:09.652174000 UTC +00:00,
   #     configuration: { ... }
@@ -37,7 +37,7 @@ module MissionControl::Jobs::Adapter
   #   }
   def workers
     if exposes_workers?
-      raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `workers`")
+      raise_incompatible_adapter_error_from :workers
     end
   end
 
@@ -49,60 +49,65 @@ module MissionControl::Jobs::Adapter
   #     active: true
   #   }
   def queues
-    raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `queue_names`")
+    raise_incompatible_adapter_error_from :queue_names
   end
 
   def queue_size(queue_name)
-    raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `queue_size`")
+    raise_incompatible_adapter_error_from :queue_size
   end
 
   def clear_queue(queue_name)
-    raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `clear_queue`")
+    raise_incompatible_adapter_error_from :clear_queue
   end
 
   def pause_queue(queue_name)
     if supports_queue_pausing?
-      raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `pause_queue`")
+      raise_incompatible_adapter_error_from :pause_queue
     end
   end
 
   def resume_queue(queue_name)
     if supports_queue_pausing?
-      raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `resume_queue`")
+      raise_incompatible_adapter_error_from :resume_queue
     end
   end
 
   def queue_paused?(queue_name)
     if supports_queue_pausing?
-      raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `queue_paused?`")
+      raise_incompatible_adapter_error_from :queue_paused?
     end
   end
 
   def jobs_count(jobs_relation)
-    raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `jobs_count`")
+    raise_incompatible_adapter_error_from :jobs_count
   end
 
   def fetch_jobs(jobs_relation)
-    raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `fetch_jobs`")
+    raise_incompatible_adapter_error_from :fetch_jobs
   end
 
   def retry_all_jobs(jobs_relation)
-    raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `retry_all_jobs`")
+    raise_incompatible_adapter_error_from :retry_all_jobs
   end
 
   def retry_job(job, jobs_relation)
-    raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `retry_job`")
+    raise_incompatible_adapter_error_from :retry_job
   end
 
   def discard_all_jobs(jobs_relation)
-    raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `discard_all_jobs`")
+    raise_incompatible_adapter_error_from :discard_all_jobs
   end
 
   def discard_job(job, jobs_relation)
-    raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `discard_job`")
+    raise_incompatible_adapter_error_from :discard_job
   end
 
   def find_job(job_id, *)
-    raise MissionControl::Jobs::Errors::IncompatibleAdapter("Adapter must implement `find_job`")
+    raise_incompatible_adapter_error_from :find_job
   end
+
+  private
+    def raise_incompatible_adapter_error_from(method_name)
+      raise MissionControl::Jobs::Errors::IncompatibleAdapter, "Adapter #{ActiveJob.adapter_name(self)} must implement `#{method_name}`"
+    end
 end

--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -20,8 +20,8 @@ module MissionControl
           MissionControl::Jobs.public_send("#{key}=", value)
         end
 
-        if config.active_job.queue_adapter.present? && MissionControl::Jobs.adapters.empty?
-          MissionControl::Jobs.adapters << config.active_job.queue_adapter
+        if MissionControl::Jobs.adapters.empty?
+          MissionControl::Jobs.adapters << (config.active_job.queue_adapter || :async)
         end
       end
 
@@ -43,6 +43,8 @@ module MissionControl
         if MissionControl::Jobs.adapters.include?(:solid_queue)
           ActiveJob::QueueAdapters::SolidQueueAdapter.prepend ActiveJob::QueueAdapters::SolidQueueExt
         end
+
+        ActiveJob::QueueAdapters::AsyncAdapter.include MissionControl::Jobs::Adapter
       end
 
       config.after_initialize do |app|

--- a/lib/mission_control/jobs/server/serializable.rb
+++ b/lib/mission_control/jobs/server/serializable.rb
@@ -18,7 +18,7 @@ module MissionControl::Jobs::Server::Serializable
   end
 
   def to_global_id
-    suffix = ":#{id}" if application.servers.length > 1
+    suffix = ":#{id}" if application.servers.many?
     "#{application&.id}#{suffix}"
   end
 end


### PR DESCRIPTION
To be consistent with Active Job. Also, include `MissionControl::Jobs::Adapter` in the async adapter so it can fail with a proper `IncompatibleAdapter` error until support is added.

This fixes https://github.com/basecamp/mission_control-jobs/issues/56