### PR TITLE
Avoid forcing applications to have a root ApplicationJob defined

### DIFF
--- a/app/controllers/concerns/mission_control/jobs/failed_jobs_bulk_operations.rb
+++ b/app/controllers/concerns/mission_control/jobs/failed_jobs_bulk_operations.rb
@@ -12,6 +12,6 @@ module MissionControl::Jobs::FailedJobsBulkOperations
     # or causing replication lag in MySQL). This should be enough for most scenarios. For
     # cases where we need to retry a huge sets of jobs, we offer a runbook that uses the API.
     def bulk_limited_filtered_failed_jobs
-      ApplicationJob.jobs.failed.where(**@job_filters).limit(MAX_NUMBER_OF_JOBS_FOR_BULK_OPERATIONS)
+      ActiveJob::Base.jobs.failed.where(**@job_filters).limit(MAX_NUMBER_OF_JOBS_FOR_BULK_OPERATIONS)
     end
 end

--- a/app/controllers/mission_control/jobs/bulk_discards_controller.rb
+++ b/app/controllers/mission_control/jobs/bulk_discards_controller.rb
@@ -14,7 +14,7 @@ class MissionControl::Jobs::BulkDiscardsController < MissionControl::Jobs::Appli
         bulk_limited_filtered_failed_jobs
       else
         # we don't want to apply any limit since "discarding all" without parameters can be optimized in the adapter as a much faster operation
-        ApplicationJob.jobs.failed
+        ActiveJob::Base.jobs.failed
       end
     end
 end

--- a/app/controllers/mission_control/jobs/discards_controller.rb
+++ b/app/controllers/mission_control/jobs/discards_controller.rb
@@ -8,6 +8,6 @@ class MissionControl::Jobs::DiscardsController < MissionControl::Jobs::Applicati
 
   private
     def jobs_relation
-      ApplicationJob.jobs.failed
+      ActiveJob::Base.jobs.failed
     end
 end

--- a/app/controllers/mission_control/jobs/jobs_controller.rb
+++ b/app/controllers/mission_control/jobs/jobs_controller.rb
@@ -5,7 +5,7 @@ class MissionControl::Jobs::JobsController < MissionControl::Jobs::ApplicationCo
 
   def index
     @job_class_names = jobs_with_status.job_class_names
-    @queue_names = ApplicationJob.queues.map(&:name)
+    @queue_names = ActiveJob::Base.queues.map(&:name)
 
     @jobs_page = MissionControl::Jobs::Page.new(filtered_jobs_with_status, page: params[:page].to_i)
     @jobs_count = @jobs_page.total_count
@@ -24,11 +24,11 @@ class MissionControl::Jobs::JobsController < MissionControl::Jobs::ApplicationCo
     end
 
     def jobs_with_status
-      ApplicationJob.jobs.with_status(jobs_status)
+      ActiveJob::Base.jobs.with_status(jobs_status)
     end
 
     def filtered_jobs
-      ApplicationJob.jobs.where(**@job_filters)
+      ActiveJob::Base.jobs.where(**@job_filters)
     end
 
     helper_method :jobs_status

--- a/app/controllers/mission_control/jobs/queues_controller.rb
+++ b/app/controllers/mission_control/jobs/queues_controller.rb
@@ -11,14 +11,14 @@ class MissionControl::Jobs::QueuesController < MissionControl::Jobs::Application
 
   private
     def set_queue
-      @queue = ApplicationJob.queues[params[:id]]
+      @queue = ActiveJob::Base.queues[params[:id]]
     end
 
     def filtered_queues
-      if prefix = ApplicationJob.queue_name_prefix
-        ApplicationJob.queues.select { |queue| queue.name.start_with?(prefix) }
+      if prefix = ActiveJob::Base.queue_name_prefix
+        ActiveJob::Base.queues.select { |queue| queue.name.start_with?(prefix) }
       else
-        ApplicationJob.queues
+        ActiveJob::Base.queues
       end
     end
 end

--- a/app/controllers/mission_control/jobs/retries_controller.rb
+++ b/app/controllers/mission_control/jobs/retries_controller.rb
@@ -8,6 +8,6 @@ class MissionControl::Jobs::RetriesController < MissionControl::Jobs::Applicatio
 
   private
     def jobs_relation
-      ApplicationJob.jobs.failed
+      ActiveJob::Base.jobs.failed
     end
 end

--- a/app/helpers/mission_control/jobs/navigation_helper.rb
+++ b/app/helpers/mission_control/jobs/navigation_helper.rb
@@ -45,7 +45,7 @@ module MissionControl::Jobs::NavigationHelper
   end
 
   def jobs_count_with_status(status)
-    count = ApplicationJob.jobs.with_status(status).count
+    count = ActiveJob::Base.jobs.with_status(status).count
     count.infinite? ? "..." : number_to_human(count)
   end
 end

--- a/app/jobs/mission_control/jobs/application_job.rb
+++ b/app/jobs/mission_control/jobs/application_job.rb
@@ -1,6 +1,0 @@
-module MissionControl
-  module Jobs
-    class ApplicationJob < ActiveJob::Base
-    end
-  end
-end


### PR DESCRIPTION
While trying out mission control in an existing application, I encountered some errors whose origin is the fact that there is no root `ApplicationJob`.

Mission control defines its own `MissionControl::Jobs::ApplicationJob`, however it doesn't seem to be used due to how each files' class is defined:

```ruby
module MissionControl::Jobs::FailedJobsBulkOperations
  def bulk_limited_filtered_failed_jobs
      ApplicationJob.jobs # would work with MissionControl::Jobs::FailedJobsBulkOperations::ApplicationJob or ::ApplicationJob
    end
end
```

This is a proposal to use `ActiveJob::Base` in application code instead so it is compatible with applications that don't have a root ApplicationJob. Furthermore, this removes the unused `MissionControl::Jobs::ApplicationJob`.