### PR TITLE
Move tbody tag to the correct place in the jobs page

### DIFF
--- a/app/views/mission_control/jobs/jobs/_jobs_page.html.erb
+++ b/app/views/mission_control/jobs/jobs/_jobs_page.html.erb
@@ -1,15 +1,13 @@
 <table class="jobs <%= jobs_status %> table queues is-hoverable is-fullwidth">
-  <tbody>
   <thead>
-  <tr>
-    <th style="width: 35%;">Job</th>
-    <% attribute_names_for_job_status(jobs_status).each do |attribute| %>
-      <th><%= attribute %></th>
-    <% end %>
-  </tr>
+    <tr>
+      <th style="width: 35%;">Job</th>
+      <% attribute_names_for_job_status(jobs_status).each do |attribute| %>
+        <th><%= attribute %></th>
+      <% end %>
+    </tr>
   </thead>
-
-  <%= render partial: "mission_control/jobs/jobs/job", collection: jobs_page.jobs %>
-
+  <tbody>
+    <%= render partial: "mission_control/jobs/jobs/job", collection: jobs_page.jobs %>
   </tbody>
 </table>


### PR DESCRIPTION
Just a small fix moving the `tbody` tag to the right place and fixing indentation.

<img width="1305" alt="Screenshot 2024-02-18 at 0 33 42" src="https://github.com/basecamp/mission_control-jobs/assets/7331511/90c5ff4d-28c7-4e60-a26b-e8c17a4f3291">

Reference https://www.w3schools.com/tags/tag_thead.asp
