### PR TITLE
Support dispatching blocked jobs directly from the UI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,8 +330,12 @@ PLATFORMS
   aarch64-linux
   arm-linux
   arm64-darwin
+  arm64-darwin-21
+  arm64-darwin-22
   x86-linux
   x86_64-darwin
+  x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/mission_control/jobs/dispatches_controller.rb
+++ b/app/controllers/mission_control/jobs/dispatches_controller.rb
@@ -1,0 +1,13 @@
+class MissionControl::Jobs::DispatchesController < MissionControl::Jobs::ApplicationController
+  include MissionControl::Jobs::JobScoped
+
+  def create
+    @job.dispatch
+    redirect_to application_jobs_url(@application, :blocked), notice: "Dispatched job with id #{@job.job_id}"
+  end
+
+  private
+  def jobs_relation
+    ApplicationJob.jobs.blocked
+  end
+end

--- a/app/helpers/mission_control/jobs/jobs_helper.rb
+++ b/app/helpers/mission_control/jobs/jobs_helper.rb
@@ -18,7 +18,7 @@ module MissionControl::Jobs::JobsHelper
   def attribute_names_for_job_status(status)
     case status.to_s
     when "failed"      then [ "Error", "" ]
-    when "blocked"     then [ "Queue", "Blocked by", "Block expiry" ]
+    when "blocked"     then [ "Queue", "Blocked by", "Block expiry", "" ]
     when "finished"    then [ "Queue", "Finished" ]
     when "scheduled"   then [ "Queue", "Scheduled", "" ]
     when "in_progress" then [ "Queue", "Run by", "Running for" ]

--- a/app/views/mission_control/jobs/jobs/_title.html.erb
+++ b/app/views/mission_control/jobs/jobs/_title.html.erb
@@ -8,6 +8,9 @@
       <% if job.failed? %>
         <%= render "mission_control/jobs/jobs/failed/actions", job: job %>
       <% end %>
+      <% if job.blocked? %>
+        <%= render "mission_control/jobs/jobs/blocked/actions", job: job %>
+      <% end %>
     </div>
   </div>
 </h1>

--- a/app/views/mission_control/jobs/jobs/blocked/_actions.html.erb
+++ b/app/views/mission_control/jobs/jobs/blocked/_actions.html.erb
@@ -1,0 +1,3 @@
+<div class="buttons is-right">
+  <%= button_to "Dispatch", application_job_dispatch_path(@application, job.job_id), class: "button is-warning is-light mr-0" %>
+</div>

--- a/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
+++ b/app/views/mission_control/jobs/jobs/blocked/_job.html.erb
@@ -1,3 +1,6 @@
 <td><%= link_to job.queue_name, application_queue_path(@application, job.queue) %></td>
 <td><div class="is-family-monospace is-size-7"><%= job.blocked_by %></div></td>
 <td><%= bidirectional_time_distance_in_words_with_title(job.blocked_until) %></td>
+<td class="pr-0">
+  <%= render "mission_control/jobs/jobs/blocked/actions", job: job %>
+</td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ MissionControl::Jobs::Engine.routes.draw do
     resources :jobs, only: :show do
       resource :retry, only: :create
       resource :discard, only: :create
+      resource :dispatch, only: :create
 
       collection do
         resource :bulk_retries, only: :create

--- a/lib/active_job/executing.rb
+++ b/lib/active_job/executing.rb
@@ -4,9 +4,8 @@ module ActiveJob::Executing
   extend ActiveSupport::Concern
 
   included do
-    attr_accessor :raw_data, :position, :finished_at, :blocked_by, :blocked_until, :worker_id, :started_at
+    attr_accessor :raw_data, :position, :finished_at, :blocked_by, :blocked_until, :worker_id, :started_at, :status
     attr_reader :serialized_arguments
-    attr_writer :status
 
     thread_cattr_accessor :current_queue_adapter
   end
@@ -25,10 +24,8 @@ module ActiveJob::Executing
     jobs_relation_for_discarding.discard_job(self)
   end
 
-  def status
-    return @status if @status.present?
-
-    failed? ? :failed : :pending
+  def dispatch
+    ActiveJob.jobs.blocked.dispatch_job(self)
   end
 
   private

--- a/lib/active_job/failed.rb
+++ b/lib/active_job/failed.rb
@@ -4,8 +4,4 @@ module ActiveJob::Failed
   included do
     attr_accessor :last_execution_error, :failed_at
   end
-
-  def failed?
-    last_execution_error.present?
-  end
 end

--- a/lib/active_job/job_proxy.rb
+++ b/lib/active_job/job_proxy.rb
@@ -23,4 +23,10 @@ class ActiveJob::JobProxy < ActiveJob::Base
   def perform_now
     raise UnsupportedError, "A JobProxy doesn't support immediate execution, only enqueuing."
   end
+
+  ActiveJob::JobsRelation::STATUSES.each do |status|
+    define_method "#{status}?" do
+      self.status == status
+    end
+  end
 end

--- a/lib/active_job/jobs_relation.rb
+++ b/lib/active_job/jobs_relation.rb
@@ -147,6 +147,11 @@ class ActiveJob::JobsRelation
     queue_adapter.discard_job(job, self)
   end
 
+  # Dispatch the provided job.
+  def dispatch_job(job)
+    queue_adapter.dispatch_job(job, self)
+  end
+
   # Find a job by id.
   #
   # Returns nil when not found.

--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -82,6 +82,10 @@ module ActiveJob::QueueAdapters::SolidQueueExt
     find_solid_queue_job!(job.job_id, jobs_relation).discard
   end
 
+  def dispatch_job(job, jobs_relation)
+    dispatch_immediately find_solid_queue_job!(job.job_id, jobs_relation)
+  end
+
   def find_job(job_id, *)
     if job = SolidQueue::Job.where(active_job_id: job_id).order(:id).last
       deserialize_and_proxy_solid_queue_job job
@@ -143,6 +147,13 @@ module ActiveJob::QueueAdapters::SolidQueueExt
           error_class: solid_queue_job.failed_execution.exception_class,
           message: solid_queue_job.failed_execution.message,
           backtrace: solid_queue_job.failed_execution.backtrace
+      end
+    end
+
+    def dispatch_immediately(job)
+      SolidQueue::Job.transaction do
+        job.dispatch_bypassing_concurrency_limits
+        job.blocked_execution.destroy!
       end
     end
 

--- a/lib/mission_control/jobs/adapter.rb
+++ b/lib/mission_control/jobs/adapter.rb
@@ -102,6 +102,10 @@ module MissionControl::Jobs::Adapter
     raise_incompatible_adapter_error_from :discard_job
   end
 
+  def dispatch_job(job, jobs_relation)
+    raise_incompatible_adapter_error_from :dispatch_job
+  end
+
   def find_job(job_id, *)
     raise_incompatible_adapter_error_from :find_job
   end

--- a/test/active_job/queue_adapters/adapter_testing/dispatch_jobs.rb
+++ b/test/active_job/queue_adapters/adapter_testing/dispatch_jobs.rb
@@ -1,0 +1,19 @@
+module ActiveJob::QueueAdapters::AdapterTesting::DispatchJobs
+  extend ActiveSupport::Testing::Declarative
+
+  test "dispatch blocked job immediately" do
+    10.times { |index| BlockingJob.perform_later(index * 0.1.seconds) }
+
+    # Given, there is one pending and the others are blocked
+    pending_jobs = ActiveJob.jobs.pending
+    assert_equal 1, pending_jobs.size
+    blocked_jobs = ActiveJob.jobs.blocked
+    assert_equal 9, blocked_jobs.size
+
+    blocked_jobs.each(&:dispatch)
+
+    # Then, all blocked jobs are pending
+    assert_empty blocked_jobs.reload
+    assert_equal 10, pending_jobs.reload.size
+  end
+end

--- a/test/active_job/queue_adapters/solid_queue_test.rb
+++ b/test/active_job/queue_adapters/solid_queue_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class ActiveJob::QueueAdapters::SolidQueueTest < ActiveSupport::TestCase
   include ActiveJob::QueueAdapters::AdapterTesting
+  include DispatchJobs
 
   setup do
     SolidQueue.logger = ActiveSupport::Logger.new(nil)

--- a/test/dummy/app/jobs/blocking_job.rb
+++ b/test/dummy/app/jobs/blocking_job.rb
@@ -1,0 +1,7 @@
+class BlockingJob < ApplicationJob
+  limits_concurrency key: ->(*args) { "exclusive" }
+
+  def perform(pause = nil)
+    sleep(pause) if pause
+  end
+end


### PR DESCRIPTION
Introduce the dispatch action to blocked jobs

Closes #37

![image](https://github.com/basecamp/mission_control-jobs/assets/14901139/9804aaf0-8c6c-4505-b3b7-dd39e2cf8d91)
