### PR TITLE
Titleize navigation status tab

### DIFF
--- a/app/helpers/mission_control/jobs/navigation_helper.rb
+++ b/app/helpers/mission_control/jobs/navigation_helper.rb
@@ -4,7 +4,7 @@ module MissionControl::Jobs::NavigationHelper
   def navigation_sections
     { queues: [ "Queues", application_queues_path(@application) ] }.tap do |sections|
       supported_job_statuses.without(:pending).each do |status|
-         sections[navigation_section_for_status(status)] = [ "#{status.to_s.titleize} jobs (#{jobs_count_with_status(status)})", application_jobs_path(@application, status) ]
+         sections[navigation_section_for_status(status)] = [ status_title_tab(status), application_jobs_path(@application, status) ]
       end
 
       sections[:workers] = [ "Workers", application_workers_path(@application) ] if workers_exposed?
@@ -47,5 +47,9 @@ module MissionControl::Jobs::NavigationHelper
   def jobs_count_with_status(status)
     count = ApplicationJob.jobs.with_status(status).count
     count.infinite? ? "..." : number_to_human(count)
+  end
+
+  def status_title_tab(status)
+    "#{status.to_s.titleize} Jobs (#{jobs_count_with_status(status)})"
   end
 end


### PR DESCRIPTION
Update from `job` to `Job` on each job status tab title

before
<img width="999" alt="before" src="https://github.com/basecamp/mission_control-jobs/assets/7331511/14b9ae99-3897-40d7-ace3-c4238b46fa0f">


After
<img width="1001" alt="after" src="https://github.com/basecamp/mission_control-jobs/assets/7331511/6eded6c4-3b0a-4732-ba41-9d4a529b5582">
