### PR TITLE
Add arm64-darwin-23 platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
This was added when doing `bundle` in the repo on my computer

An alternative would be to use `arm64-darwin`