### PR TITLE
Add config.mission_control.jobs.irb_help that defaults to true

### DIFF
--- a/lib/mission_control/jobs.rb
+++ b/lib/mission_control/jobs.rb
@@ -16,5 +16,6 @@ module MissionControl
     mattr_accessor :delay_between_bulk_operation_batches, default: 0
     mattr_accessor :logger, default: ActiveSupport::Logger.new(nil)
     mattr_accessor :internal_query_count_limit, default: 500_000 # Hard limit to keep unlimited count queries fast enough
+    mattr_accessor :show_console_help, default: true
   end
 end

--- a/lib/mission_control/jobs/engine.rb
+++ b/lib/mission_control/jobs/engine.rb
@@ -79,7 +79,9 @@ module MissionControl
           MissionControl::Jobs::Current.server = application.servers.first
         end
 
-        puts "\n\nType 'jobs_help' to see how to connect to the available job servers to manage jobs\n\n"
+        if MissionControl::Jobs.show_console_help
+          puts "\n\nType 'jobs_help' to see how to connect to the available job servers to manage jobs\n\n"
+        end
       end
 
       initializer "mission_control-jobs.assets" do |app|


### PR DESCRIPTION
To display or hide the irb help message

Fixes #76