### PR TITLE
Find most recent job by active_job_id in Solid Queue RelationAdapter (Fixes #78)

### DIFF
--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -169,7 +169,7 @@ module ActiveJob::QueueAdapters::SolidQueueExt
       end
 
       def find_job(active_job_id)
-        if job = SolidQueue::Job.find_by(active_job_id: active_job_id)
+        if job = SolidQueue::Job.where(active_job_id: active_job_id).order(:id).last
           job if matches_relation_filters?(job)
         end
       end


### PR DESCRIPTION
Retrieve the most recent job when there are multiple solid queue jobs for the same active_job_id. Fixes #78 by returning the final failed job when retry_on is used.