### PR TITLE
Upgrade rubocop from 1.52.1 to 1.62.0 and relax dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ gem "sqlite3"
 
 gem "sprockets-rails"
 gem "solid_queue", bc: "solid_queue", require: false
-gem "rubocop-37signals", bc: "house-style", require: false
+gem "rubocop-37signals"
 gem "puma"
 gem "capybara", github: "teamcapybara/capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/basecamp/house-style
-  revision: a9ca7e4ab80b72c1a10053c50efefe8cd275e3b8
-  specs:
-    rubocop-37signals (1.0.0)
-      rubocop
-      rubocop-minitest
-      rubocop-performance
-      rubocop-rails
-
-GIT
   remote: https://github.com/basecamp/solid_queue
   revision: d71aa8ad6dd435fc458fc07be5ecc3b0cf4e89de
   specs:
@@ -144,6 +134,7 @@ GEM
       rdoc
       reline (>= 0.4.2)
     json (2.7.1)
+    language_server-protocol (3.17.0.3)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -254,18 +245,24 @@ GEM
       multi_json (~> 1.0)
       resque (>= 1.9.10)
     rexml (3.2.6)
-    rubocop (1.52.1)
+    rubocop (1.62.0)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.3)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.30.0)
-      parser (>= 3.2.1.0)
+    rubocop-37signals (1.0.0)
+      rubocop
+      rubocop-minitest
+      rubocop-performance
+      rubocop-rails
+    rubocop-ast (1.31.1)
+      parser (>= 3.3.0.4)
     rubocop-minitest (0.34.5)
       rubocop (>= 1.39, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
@@ -348,8 +345,8 @@ DEPENDENCIES
   redis-namespace
   resque
   resque-pause
-  rubocop (~> 1.52.0)
-  rubocop-37signals!
+  rubocop
+  rubocop-37signals
   rubocop-performance
   rubocop-rails
   selenium-webdriver

--- a/mission_control-jobs.gemspec
+++ b/mission_control-jobs.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "debug"
   spec.add_development_dependency "redis", "~> 4.0.0"
   spec.add_development_dependency "redis-namespace"
-  spec.add_development_dependency "rubocop", "~> 1.52.0"
+  spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "rubocop-rails"
 end


### PR DESCRIPTION
I also had to install rubocop-37signals from rubygems