### PR TITLE
Remove unused platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,12 +330,8 @@ PLATFORMS
   aarch64-linux
   arm-linux
   arm64-darwin
-  arm64-darwin-21
-  arm64-darwin-22
   x86-linux
   x86_64-darwin
-  x86_64-darwin-22
-  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
The generic versions without the year are enough