### PR TITLE
Fix workers pagination issue where the whole relation was being loaded

### DIFF
--- a/app/controllers/mission_control/jobs/workers_controller.rb
+++ b/app/controllers/mission_control/jobs/workers_controller.rb
@@ -7,7 +7,7 @@ class MissionControl::Jobs::WorkersController < MissionControl::Jobs::Applicatio
   end
 
   def show
-    @worker = current_server.find_worker(params[:id])
+    @worker = MissionControl::Jobs::Current.server.find_worker(params[:id])
   end
 
   private
@@ -17,11 +17,7 @@ class MissionControl::Jobs::WorkersController < MissionControl::Jobs::Applicatio
       end
     end
 
-  def current_server
-    MissionControl::Jobs::Current.server
-  end
-
-  def workers_relation
-    current_server.workers_relation
-  end
+    def workers_relation
+      MissionControl::Jobs::Current.server.workers_relation
+    end
 end

--- a/app/models/mission_control/jobs/page.rb
+++ b/app/models/mission_control/jobs/page.rb
@@ -34,7 +34,7 @@ class MissionControl::Jobs::Page
   end
 
   def pages_count
-    (total_count.to_f / 10).ceil unless total_count.infinite?
+    (total_count.to_f / page_size).ceil unless total_count.infinite?
   end
 
   def total_count

--- a/lib/active_job/queue_adapters/solid_queue_ext.rb
+++ b/lib/active_job/queue_adapters/solid_queue_ext.rb
@@ -80,10 +80,6 @@ module ActiveJob::QueueAdapters::SolidQueueExt
   end
 
   private
-    def worker_from_solid_queue_process(process)
-      MissionControl::Jobs::Worker.new(queue_adapter: self, **worker_attributes_from_solid_queue_process(process))
-    end
-
     def find_queue_by_name(queue_name)
       SolidQueue::Queue.find_by_name(queue_name)
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -94,6 +94,10 @@ class ActionDispatch::IntegrationTest
       ActiveJob::QueueAdapters::SolidQueueAdapter.new
     end
 
+    def register_workers(count: 1)
+      count.times { |i| SolidQueue::Process.register(kind: "Worker", pid: i) }
+    end
+
     def perform_enqueued_jobs_async(wait: 1.second)
       @worker.start
       sleep(wait)


### PR DESCRIPTION
This is a follow-up on #28. 

Due to the delegation of all count-related methods to `to_a`, we were loading the whole set of workers when calculating the number of pages and page size, which happens before we've set any limits or offsets in the relation. Moreover, once the limits and offsets were set, we weren't resetting the loaded workers, which means we were still returning all of them even with offset and limit.

I'd like to DRY a bit the two `JobsRelation` and `WorkersRelation` classes, which have a lot in common now, but this will do for now. 